### PR TITLE
Improve github jest logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
       id: cpu-cores
       uses: SimenB/github-actions-cpu-cores@v2
     - name: Run tests
-      run: yarn run test --max-workers ${{ steps.cpu-cores.outputs.count }} --reporters github-actions summary
+      run: yarn run test --max-workers ${{ steps.cpu-cores.outputs.count }}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -35,6 +35,13 @@ const config: Config = {
             },
         ],
     },
+
+    verbose: true,
 };
+
+/* CI specific config */
+if (process.env.CI != undefined && process.env.CI != "0" && process.env.CI != "") {
+    config.reporters = [["github-actions", { silent: false }], "summary"];
+}
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "format": "yarn run prettier --write '**/*.{ts,js,cjs,json}'",
         "lint:check": "yarn run eslint src --ext .js,.jsx,.ts,.tsx",
         "lint": "yarn run eslint src --ext .js,.jsx,.ts,.tsx --fix",
-        "test": "jest --verbose",
+        "test": "jest",
         "build": "tsc",
         "verify": "yarn build && yarn lint:check && yarn format:check",
         "serve": "node scripts/serve.mjs",


### PR DESCRIPTION
This is a simple enhancement to make jest logs appear better in the github actions view.

This works by making jest tests verbose, and to use proper reporter settings, so you get nice dropdowns like this:

![image](https://github.com/HackIllinois/adonix/assets/105177619/ae1acf81-498f-473e-8e9d-f286d675f6da)

Note: Ignore the mess that follows, the only good way to test this is by having a real PR...