### PR TITLE
added /profile/addpoints and tests

### DIFF
--- a/src/services/profile/profile-lib.ts
+++ b/src/services/profile/profile-lib.ts
@@ -38,5 +38,5 @@ export async function updatePoints(userId: string, amount: number): Promise<Atte
         },
     };
 
-    return Models.AttendeeProfile.findOneAndUpdate({ userId: userId }, updateQuery);
+    return Models.AttendeeProfile.findOneAndUpdate({ userId: userId }, updateQuery, { new: true });
 }

--- a/src/services/profile/profile-router.test.ts
+++ b/src/services/profile/profile-router.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from "@jest/globals";
 import Models from "../../database/models.js";
-import { TESTER, delAsUser, getAsAdmin, getAsUser, postAsAttendee, postAsUser } from "../../testTools.js";
+import { TESTER, delAsUser, getAsAdmin, getAsUser, getAsStaff, postAsAttendee, postAsUser } from "../../testTools.js";
 import { ProfileFormat } from "./profile-formats.js";
 import Config from "../../config.js";
 import { AttendeeMetadata, AttendeeProfile } from "database/attendee-db.js";
@@ -174,7 +174,7 @@ describe("GET /profile/leaderboard", () => {
 
 describe("GET /profile/addpoints", () => {
     it("works for Staff", async () => {
-        const response = await getAsAdmin("/profile/addpoints")
+        const response = await getAsStaff("/profile/addpoints")
             .send({
                 userId: TESTER.id,
                 points: 10,
@@ -196,7 +196,7 @@ describe("GET /profile/addpoints", () => {
     });
 
     it("returns UserNotFound for nonexistent users", async () => {
-        const response = await getAsAdmin("/profile/addpoints")
+        const response = await getAsStaff("/profile/addpoints")
             .send({
                 userId: "idontexists",
                 points: 10,

--- a/src/services/profile/profile-router.test.ts
+++ b/src/services/profile/profile-router.test.ts
@@ -171,3 +171,38 @@ describe("GET /profile/leaderboard", () => {
         expect(JSON.parse(response.text)).toHaveProperty("error", "InvalidLimit");
     });
 });
+
+describe("GET /profile/addpoints", () => {
+    it("works for Staff", async () => {
+        const response = await getAsAdmin("/profile/addpoints")
+            .send({
+                userId: TESTER.id,
+                points: 10,
+            })
+            .expect(StatusCode.SuccessOK);
+
+        expect(JSON.parse(response.text)).toHaveProperty("points", 10);
+    });
+
+    it("returns Forbidden error for users", async () => {
+        const response = await getAsUser("/profile/addpoints")
+            .send({
+                userId: TESTER.id,
+                points: 10,
+            })
+            .expect(StatusCode.ClientErrorForbidden);
+
+        expect(JSON.parse(response.text)).toHaveProperty("error", "Forbidden");
+    });
+
+    it("returns UserNotFound for nonexistent users", async () => {
+        const response = await getAsAdmin("/profile/addpoints")
+            .send({
+                userId: "idontexists",
+                points: 10,
+            })
+            .expect(StatusCode.ClientErrorBadRequest);
+
+        expect(JSON.parse(response.text)).toHaveProperty("error", "UserNotFound");
+    });
+});

--- a/src/services/profile/profile-router.ts
+++ b/src/services/profile/profile-router.ts
@@ -287,4 +287,61 @@ profileRouter.delete("/", strongJwtVerification, async (_: Request, res: Respons
     return res.status(StatusCode.SuccessOK).send({ success: true });
 });
 
+/**
+ * @api {get} /profile/addpoints/ GET /profile/addpoints/
+ * @apiGroup Profile
+ * @apiDescription Add points to the specified user, given that the currently authenticated user has elevated perms.
+ *
+ * @apiBody {String} userId User to add points to.
+ * @apiBody {int} points Number of points to add.
+ *
+ * @apiSuccess (200: Success) {string} userID ID of the user
+ * @apiSuccess (200: Success) {string} displayName Publicly-visible display name for the user
+ * @apiSuccess (200: Success) {string} discordTag Discord tag for the user
+ * @apiSuccess (200: Success) {string} avatarUrl URL that contains the user avatar
+ * @apiSuccess (200: Success) {number} points Points that the user has
+ *
+ * @apiSuccessExample Example Success Response:
+ * HTTP/1.1 200 OK
+ * {
+ *    "_id": "abc12345",
+ *    "userId": "github12345",
+ *    "displayName": "Hack",
+ *    "discord": "HackIllinois",
+ *    "avatarUrl": "na",
+ *    "points": 10,
+ * }
+ *
+ * @apiError (403: Forbidden) {String} Forbidden API accessed by user without valid perms.
+ * @apiError (400: Forbidden) {String} User not found in database.
+ */
+
+profileRouter.get("/addpoints", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+    const points: number = req.body.points;
+    const userId: string = req.body.userId;
+
+    const payload: JwtPayload = res.locals.payload as JwtPayload;
+
+    //Sends error if caller doesn't have elevated perms
+    if (!hasElevatedPerms(payload)) {
+        return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
+    }
+
+    const queryResult: AttendeeProfile | null = await Models.AttendeeProfile.findOne({ userId: userId });
+
+    if (!queryResult) {
+        return next(new RouterError(StatusCode.ClientErrorBadRequest, "UserNotFound"));
+    }
+
+    const updatedProfile: AttendeeProfile | null = await Models.AttendeeProfile.findOneAndUpdate(
+        { userId: userId },
+        {
+            points: queryResult.points + points,
+        },
+        { new: true },
+    );
+
+    return res.status(StatusCode.SuccessOK).send(updatedProfile);
+});
+
 export default profileRouter;

--- a/src/services/profile/profile-router.ts
+++ b/src/services/profile/profile-router.ts
@@ -3,7 +3,7 @@ import { Request, Router } from "express";
 import { NextFunction, Response } from "express-serve-static-core";
 
 import Config from "../../config.js";
-import { isValidLimit } from "./profile-lib.js";
+import { isValidLimit, updatePoints } from "./profile-lib.js";
 import { AttendeeMetadata, AttendeeProfile } from "../../database/attendee-db.js";
 import Models from "../../database/models.js";
 import { Query } from "mongoose";
@@ -333,13 +333,9 @@ profileRouter.get("/addpoints", strongJwtVerification, async (req: Request, res:
         return next(new RouterError(StatusCode.ClientErrorBadRequest, "UserNotFound"));
     }
 
-    const updatedProfile: AttendeeProfile | null = await Models.AttendeeProfile.findOneAndUpdate(
-        { userId: userId },
-        {
-            points: queryResult.points + points,
-        },
-        { new: true },
-    );
+    await updatePoints(userId, points);
+
+    const updatedProfile: AttendeeProfile | null = await Models.AttendeeProfile.findOne({ userId: userId });
 
     return res.status(StatusCode.SuccessOK).send(updatedProfile);
 });


### PR DESCRIPTION
Added GET /profile/addpoints & tests for it.
takes a body of the following format
{
    "userId": abcccccc,
    "points": 10,
}
where userId is the specified user to add points to, and points is the number of points to add.
This endpoint can only be accessed by Staff/Admin, and can be used internally within the scanning qr code endpoint to add points whenever an attendee scans an event qr code.