### PR TITLE
Fix GET /event discrepancy

### DIFF
--- a/src/services/event/event-lib.ts
+++ b/src/services/event/event-lib.ts
@@ -20,7 +20,7 @@ export function createFilteredEventView(baseEvent: Event): FilteredEventView {
         eventType: baseEvent.eventType as PUBLIC_EVENT_TYPE,
         points: baseEvent.points ?? 0,
         isAsync: baseEvent.isAsync,
-        mapImageURL: baseEvent.mapImageUrl,
+        mapImageUrl: baseEvent.mapImageUrl,
     };
     return publicEvent;
 }

--- a/src/services/event/event-models.ts
+++ b/src/services/event/event-models.ts
@@ -29,5 +29,5 @@ export interface FilteredEventView {
     eventType: PUBLIC_EVENT_TYPE;
     points: number;
     isAsync: boolean;
-    mapImageURL?: string;
+    mapImageUrl?: string;
 }

--- a/src/services/event/event-router.ts
+++ b/src/services/event/event-router.ts
@@ -98,7 +98,7 @@ eventsRouter.get("/followers/", strongJwtVerification, async (req: Request, res:
  *     "isPrivate": true,
  *     "isAsync": true,
  *     "displayOnStaffCheckIn": true,
- *     "mapImageURL": "someurlmapthingy.com",
+ *     "mapImageUrl": "someurlmapthingy.com",
  *   }
  * }
  *
@@ -143,7 +143,7 @@ eventsRouter.get("/staff/", strongJwtVerification, async (_: Request, res: Respo
  *     ],
  *     "sponsor": "Example sponsor",
  *     "eventType": "WORKSHOP",
- *     "mapImageURL": "someurlmapthingy.com",
+ *     "mapImageUrl": "someurlmapthingy.com",
  *   }
  * }
  * @apiSuccessExample Example Success Response (Staff POV)
@@ -167,7 +167,7 @@ eventsRouter.get("/staff/", strongJwtVerification, async (_: Request, res: Respo
  *     "eventType": "WORKSHOP",
  *     "isPrivate": True,
  *     "displayOnStaffCheckIn": True,
- *     "mapImageURL": "someurlmapthingy.com",
+ *     "mapImageUrl": "someurlmapthingy.com",
  *   }
  * }
  *
@@ -233,7 +233,7 @@ eventsRouter.get("/:EVENTID/", weakJwtVerification, async (req: Request, res: Re
  *          "eventType": "WORKSHOP",
  *          "points": 10,
  *          "isAsync": false,
- *          "mapImageURL": "https://raw.githubusercontent.com/HackIllinois/adonix-metadata/main/maps/example.png"
+ *          "mapImageUrl": "https://raw.githubusercontent.com/HackIllinois/adonix-metadata/main/maps/example.png"
  *      },
  *      {
  *          "eventId": "asdcxwjda18ajd",
@@ -360,7 +360,7 @@ eventsRouter.get("/", weakJwtVerification, async (_: Request, res: Response) => 
  *   "isStaff": false,
  *   "isPrivate": false,
  *   "displayOnStaffCheckIn": false,
- *   "mapImageURL": "someurlmapthingy.com",
+ *   "mapImageUrl": "someurlmapthingy.com",
  *   "points": 100,
  *   "exp": 10000
  * }
@@ -382,7 +382,7 @@ eventsRouter.get("/", weakJwtVerification, async (_: Request, res: Response) => 
  *   "eventType": "MEETING",
  *   "isStaff": true,
  *   "isAsync": true,
- *   "mapImageURL": "someurlmapthingy.com",
+ *   "mapImageUrl": "someurlmapthingy.com",
  * }
  *
  * @apiSuccess (201: Created) {Json} event The created event details.


### PR DESCRIPTION
# Previously 
returning `mapImageURL` without token 
![image](https://github.com/HackIllinois/adonix/assets/44485522/a38bc385-bd0f-4059-9afe-3855e79e3b34)

returning `mapImageUrl` with staff token 
![image](https://github.com/HackIllinois/adonix/assets/44485522/94d8280a-ffeb-43b8-94f4-96a9804df587)

# Now - all return `mapImageUrl` 
admin/staff token 
<img width="1053" alt="image" src="https://github.com/HackIllinois/adonix/assets/44485522/42bcefbf-644b-43d0-8a85-b865e756593b">

attendee token 
<img width="1045" alt="image" src="https://github.com/HackIllinois/adonix/assets/44485522/33dd4c86-be08-4043-a084-27466ad8ea45">

no token 
<img width="1098" alt="image" src="https://github.com/HackIllinois/adonix/assets/44485522/2b9a5517-5a99-4422-976f-b3e361c512ad">

