### PR TITLE
Remove `as JWTPayload`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-strategy": "^1.0.0",
         "status-code-enum": "^1.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "zod": "^3.22.4"
     },
     "repository": "git@github.com:HackIllinois/adonix.git",
     "devDependencies": {

--- a/src/services/admission/admission-router.ts
+++ b/src/services/admission/admission-router.ts
@@ -1,13 +1,11 @@
-import { Router, Request, Response } from "express";
+import { Router } from "express";
 import { strongJwtVerification } from "../../middleware/verify-jwt.js";
 
-import { JwtPayload } from "../auth/auth-models.js";
 import { DecisionStatus, DecisionResponse, AdmissionDecision } from "../../database/admission-db.js";
 import Models from "../../database/models.js";
 import { hasElevatedPerms } from "../auth/auth-lib.js";
 import { isValidApplicantFormat } from "./admission-formats.js";
 import { StatusCode } from "status-code-enum";
-import { NextFunction } from "express-serve-static-core";
 import { RouterError } from "../../middleware/error-handler.js";
 import { performRSVP } from "./admission-lib.js";
 import { MailInfoFormat } from "../mail/mail-formats.js";
@@ -52,8 +50,8 @@ const admissionRouter: Router = Router();
  * @apiError (403: Forbidden) {String} Forbidden API accessed by user without valid perms.
  * @apiError (500: Internal Server Error) {String} InternalError occurred on the server.
  * */
-admissionRouter.get("/notsent/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const token: JwtPayload = res.locals.payload as JwtPayload;
+admissionRouter.get("/notsent/", strongJwtVerification(), async (_, res, next) => {
+    const token = res.locals.payload;
     if (!hasElevatedPerms(token)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
     }
@@ -86,8 +84,8 @@ admissionRouter.get("/notsent/", strongJwtVerification, async (_: Request, res: 
  * @apiError (409: AlreadyRSVPed) {string} Failed because RSVP has already happened.
  * @apiError (424: EmailFailed) {string} Failed because depencency (mail service) failed.
  */
-admissionRouter.put("/rsvp/accept/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+admissionRouter.put("/rsvp/accept/", strongJwtVerification(), async (_, res, next) => {
+    const payload = res.locals.payload;
     const userId: string = payload.id;
 
     const queryResult: AdmissionDecision | null = await Models.AdmissionDecision.findOne({ userId: userId });
@@ -166,8 +164,8 @@ admissionRouter.put("/rsvp/accept/", strongJwtVerification, async (_: Request, r
  * @apiError (409: AlreadyRSVPed) {string} Failed because RSVP has already happened.
  * @apiError (424: EmailFailed) {string} Failed because depencency (mail service) failed.
  */
-admissionRouter.put("/rsvp/decline/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+admissionRouter.put("/rsvp/decline/", strongJwtVerification(), async (_, res, next) => {
+    const payload = res.locals.payload;
     const userId: string = payload.id;
 
     const queryResult: AdmissionDecision | null = await Models.AdmissionDecision.findOne({ userId: userId });
@@ -246,8 +244,8 @@ admissionRouter.put("/rsvp/decline/", strongJwtVerification, async (_: Request, 
  * @apiError (500: Internal Server Error) {String} InternalError occurred on the server.
  * @apiError (403: Forbidden) {String} Forbidden API accessed by user without valid perms.
  * */
-admissionRouter.put("/update/", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const token: JwtPayload = res.locals.payload as JwtPayload;
+admissionRouter.put("/update/", strongJwtVerification(), async (req, res, next) => {
+    const token = res.locals.payload;
 
     if (!hasElevatedPerms(token)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
@@ -326,8 +324,8 @@ admissionRouter.put("/update/", strongJwtVerification, async (req: Request, res:
  *
  * @apiUse strongVerifyErrors
  */
-admissionRouter.get("/rsvp/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+admissionRouter.get("/rsvp/", strongJwtVerification(), async (_, res, next) => {
+    const payload = res.locals.payload;
     const userId: string = payload.id;
 
     if (hasElevatedPerms(payload)) {
@@ -373,10 +371,10 @@ admissionRouter.get("/rsvp/", strongJwtVerification, async (_: Request, res: Res
  *
  * @apiUse strongVerifyErrors
  */
-admissionRouter.get("/rsvp/:USERID", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+admissionRouter.get("/rsvp/:USERID", strongJwtVerification(), async (req, res, next) => {
     const userId: string | undefined = req.params.USERID;
 
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+    const payload = res.locals.payload;
 
     //Sends error if caller doesn't have elevated perms
     if (!hasElevatedPerms(payload)) {

--- a/src/services/auth/auth-lib.ts
+++ b/src/services/auth/auth-lib.ts
@@ -138,7 +138,7 @@ export function generateJwtToken(payload?: JwtPayload, shouldNotExpire?: boolean
  * @param token JWT token to decode
  * @returns Payload of the token if valid/
  */
-export function decodeJwtToken(token?: string): JwtPayload {
+export function decodeJwtToken(token?: string): string | jsonwebtoken.JwtPayload {
     if (!token) {
         throw new Error("NoToken");
     }
@@ -150,7 +150,7 @@ export function decodeJwtToken(token?: string): JwtPayload {
     }
 
     // Verify already ensures that the token isn't expired. If it is, it returns an error
-    return jsonwebtoken.verify(token, secret) as JwtPayload;
+    return jsonwebtoken.verify(token, secret);
 }
 
 /**

--- a/src/services/auth/auth-models.ts
+++ b/src/services/auth/auth-models.ts
@@ -1,17 +1,11 @@
+import z from "zod";
+
 export interface ProfileData {
     id?: string;
     login?: string;
     email: string;
     displayName?: string;
     name?: string;
-}
-
-export interface JwtPayload {
-    id: string;
-    email: string;
-    provider: string;
-    roles: Role[];
-    exp?: number;
 }
 
 export enum Role {
@@ -29,6 +23,18 @@ export enum Provider {
     GITHUB = "github",
     GOOGLE = "google",
 }
+
+export const jwtValidator = z.object({
+    /* eslint-disable-next-line no-magic-numbers */
+    id: z.string().min(1),
+    email: z.string().email(),
+    /* eslint-disable-next-line no-magic-numbers */
+    provider: z.string().min(1),
+    roles: z.array(z.nativeEnum(Role)),
+    exp: z.number().optional(),
+});
+
+export type JwtPayload = z.infer<typeof jwtValidator>;
 
 export enum RoleOperation {
     ADD = "add",

--- a/src/services/auth/auth-router.ts
+++ b/src/services/auth/auth-router.ts
@@ -51,7 +51,7 @@ passport.use(
 const authRouter: Router = Router();
 authRouter.use(express.urlencoded({ extended: false }));
 
-authRouter.get("/dev/", (req: Request, res: Response, next: NextFunction) => {
+authRouter.get("/dev/", (req, res, next) => {
     const token: string | undefined = req.query.token as string | undefined;
     if (!token) {
         return next(new RouterError(StatusCode.ClientErrorBadRequest, "NoToken"));
@@ -79,7 +79,7 @@ authRouter.get("/dev/", (req: Request, res: Response, next: NextFunction) => {
  *     HTTP/1.1 400 Bad Request
  *     {"error": "InvalidParams"}
  */
-authRouter.get("/login/github/", (req: Request, res: Response, next: NextFunction) => {
+authRouter.get("/login/github/", (req, res, next) => {
     const device: string = (req.query.device as string | undefined) ?? Config.DEFAULT_DEVICE;
 
     if (device && !Config.REDIRECT_URLS.has(device)) {
@@ -107,7 +107,7 @@ authRouter.get("/login/github/", (req: Request, res: Response, next: NextFunctio
  *     HTTP/1.1 400 Bad Request
  *     {"error": "InvalidParams"}
  */
-authRouter.get("/login/google/", (req: Request, res: Response, next: NextFunction) => {
+authRouter.get("/login/google/", (req, res, next) => {
     const device: string = (req.query.device as string | undefined) ?? Config.DEFAULT_DEVICE;
 
     if (device && !Config.REDIRECT_URLS.has(device)) {
@@ -197,9 +197,9 @@ authRouter.get(
  *
  * @apiUse strongVerifyErrors
  */
-authRouter.get("/roles/list/:ROLE", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+authRouter.get("/roles/list/:ROLE", strongJwtVerification(), async (req, res, next) => {
     const role = req.params.ROLE as string;
-    const payload = res.locals.payload as JwtPayload;
+    const payload = res.locals.payload;
 
     if (!hasElevatedPerms(payload)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
@@ -229,8 +229,8 @@ authRouter.get("/roles/list/:ROLE", strongJwtVerification, async (req: Request, 
  *
  * @apiUse strongVerifyErrors
  */
-authRouter.get("/roles/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+authRouter.get("/roles/", strongJwtVerification(), async (_, res, next) => {
+    const payload: JwtPayload = res.locals.payload;
     const targetUser: string = payload.id;
 
     await getRoles(targetUser)
@@ -266,10 +266,10 @@ authRouter.get("/roles/", strongJwtVerification, async (_: Request, res: Respons
  * @apiError (400: Bad Request) {String} UserNotFound User doesn't exist in the database.
  * @apiError (403: Forbidden) {String} Forbidden API accessed by user without valid perms.
  */
-authRouter.get("/roles/:USERID", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+authRouter.get("/roles/:USERID", strongJwtVerification(), async (req, res, next) => {
     const targetUser: string = req.params.USERID as string;
 
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+    const payload = res.locals.payload;
 
     // Cases: Target user already logged in, auth user is admin
     if (payload.id == targetUser) {
@@ -313,8 +313,8 @@ authRouter.get("/roles/:USERID", strongJwtVerification, async (req: Request, res
  * @apiError (400: Bad Request) {String} InvalidRole Nonexistent role passed in.
  * @apiUse strongVerifyErrors
  */
-authRouter.put("/roles/:OPERATION/", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+authRouter.put("/roles/:OPERATION/", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
 
     // Not authenticated with modify roles perms
     if (!hasAdminPerms(payload)) {
@@ -360,9 +360,9 @@ authRouter.put("/roles/:OPERATION/", strongJwtVerification, async (req: Request,
  *
  * @apiUse strongVerifyErrors
  */
-authRouter.get("/token/refresh", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
+authRouter.get("/token/refresh", strongJwtVerification(), async (_, res, next) => {
     // Get old data from token
-    const oldPayload: JwtPayload = res.locals.payload as JwtPayload;
+    const oldPayload = res.locals.payload;
     const data: ProfileData = {
         id: oldPayload.id,
         email: oldPayload.email,

--- a/src/services/mail/mail-router.ts
+++ b/src/services/mail/mail-router.ts
@@ -1,19 +1,18 @@
 // POST /registration/
 // ➡️ send confirmation email to the email provided in application
 
-import { NextFunction, Request, Response, Router } from "express";
+import { Router } from "express";
 import { strongJwtVerification } from "../../middleware/verify-jwt.js";
 import { RouterError } from "../../middleware/error-handler.js";
 import { StatusCode } from "status-code-enum";
 import { hasElevatedPerms } from "../auth/auth-lib.js";
-import { JwtPayload } from "../auth/auth-models.js";
 import { MailInfoFormat, isValidMailInfo } from "./mail-formats.js";
 import { sendMailWrapper } from "./mail-lib.js";
 
 const mailRouter: Router = Router();
 
-mailRouter.post("/send/", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+mailRouter.post("/send/", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
 
     if (!hasElevatedPerms(payload)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));

--- a/src/services/newsletter/newsletter-router.ts
+++ b/src/services/newsletter/newsletter-router.ts
@@ -1,11 +1,11 @@
-import { Request, Response, Router } from "express";
+import { Router } from "express";
+
 import { SubscribeRequest } from "./newsletter-formats.js";
 import { NewsletterSubscription } from "../../database/newsletter-db.js";
 import Models from "../../database/models.js";
 import { UpdateQuery } from "mongoose";
 import { StatusCode } from "status-code-enum";
 import { RouterError } from "../../middleware/error-handler.js";
-import { NextFunction } from "express-serve-static-core";
 
 const newsletterRouter: Router = Router();
 
@@ -31,7 +31,7 @@ const newsletterRouter: Router = Router();
  *     HTTP/1.1 400 Bad Request
  *     {"error": "InvalidParams"}
  */
-newsletterRouter.post("/subscribe/", async (request: Request, res: Response, next: NextFunction) => {
+newsletterRouter.post("/subscribe/", async (request, res, next) => {
     const requestBody: SubscribeRequest = request.body as SubscribeRequest;
     const listName: string | undefined = requestBody.listName;
     const emailAddress: string | undefined = requestBody.emailAddress;

--- a/src/services/registration/registration-router.ts
+++ b/src/services/registration/registration-router.ts
@@ -1,6 +1,5 @@
 import { StatusCode } from "status-code-enum";
-import { NextFunction } from "express-serve-static-core";
-import { Request, Response, Router } from "express";
+import { Router } from "express";
 
 import { RegistrationTemplates } from "../../config.js";
 import { strongJwtVerification } from "../../middleware/verify-jwt.js";
@@ -13,7 +12,6 @@ import { AdmissionDecision, DecisionStatus } from "../../database/admission-db.j
 import { RegistrationFormat, isValidRegistrationFormat } from "./registration-formats.js";
 
 import { hasElevatedPerms } from "../auth/auth-lib.js";
-import { JwtPayload } from "../auth/auth-models.js";
 
 import { sendMail } from "../mail/mail-lib.js";
 import { MailInfoFormat } from "../mail/mail-formats.js";
@@ -74,8 +72,8 @@ const registrationRouter: Router = Router();
  * @apiError (404: Not Found) {String} NotFound Registration does not exist
  * @apiUse strongVerifyErrors
  */
-registrationRouter.get("/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload;
+registrationRouter.get("/", strongJwtVerification(), async (_, res, next) => {
+    const payload = res.locals.payload;
     const registrationData: RegistrationApplication | null = await Models.RegistrationApplication.findOne({
         userId: payload.id,
     });
@@ -144,9 +142,9 @@ registrationRouter.get("/", strongJwtVerification, async (_: Request, res: Respo
  * @apiError (403: Forbidden) {String} Forbidden User doesn't have elevated permissions
  * @apiError (404: Not Found) {String} NotFound Registration does not exist
  */
-registrationRouter.get("/userid/:USERID", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+registrationRouter.get("/userid/:USERID", strongJwtVerification(), async (req, res, next) => {
     const userId: string | undefined = req.params.USERID;
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+    const payload = res.locals.payload;
 
     if (!hasElevatedPerms(payload)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
@@ -255,8 +253,8 @@ registrationRouter.get("/userid/:USERID", strongJwtVerification, async (req: Req
  * @apiError (500: Internal Server Error) {String} InternalError Server-side error
  * @apiUse strongVerifyErrors
  */
-registrationRouter.post("/", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+registrationRouter.post("/", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
     const userId: string = payload.id;
 
     const registrationData: RegistrationFormat = req.body as RegistrationFormat;
@@ -296,8 +294,8 @@ registrationRouter.post("/", strongJwtVerification, async (req: Request, res: Re
  * @apiError (422: Unprocessable Entity) {String} AlreadySubmitted User already submitted application (cannot POST more than once)
  * @apiError (500: Internal Server Error) {String} InternalError Server-side error
  **/
-registrationRouter.post("/submit/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+registrationRouter.post("/submit/", strongJwtVerification(), async (_, res, next) => {
+    const payload = res.locals.payload;
     const userId: string = payload.id;
 
     const registrationInfo: RegistrationApplication | null = await Models.RegistrationApplication.findOne({ userId: userId });

--- a/src/services/s3/s3-router.ts
+++ b/src/services/s3/s3-router.ts
@@ -1,6 +1,5 @@
-import { Request, Response, Router } from "express";
+import { Router } from "express";
 import { strongJwtVerification } from "../../middleware/verify-jwt.js";
-import { JwtPayload } from "../auth/auth-models.js";
 import { StatusCode } from "status-code-enum";
 import { hasElevatedPerms } from "../auth/auth-lib.js";
 
@@ -25,8 +24,8 @@ const s3Router: Router = Router();
         "url": "https://resume-bucket-dev.s3.us-east-2.amazonaws.com/randomuser?randomstuffs",
    }
  */
-s3Router.get("/upload/", strongJwtVerification, s3ClientMiddleware, async (_req: Request, res: Response) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+s3Router.get("/upload/", strongJwtVerification(), s3ClientMiddleware, async (_req, res) => {
+    const payload = res.locals.payload;
     const s3 = res.locals.s3 as S3;
     const userId: string = payload.id;
 
@@ -59,8 +58,8 @@ s3Router.get("/upload/", strongJwtVerification, s3ClientMiddleware, async (_req:
         "url": "https://resume-bucket-dev.s3.us-east-2.amazonaws.com/randomuser?randomstuffs",
    }
  */
-s3Router.get("/download/", strongJwtVerification, s3ClientMiddleware, async (_req: Request, res: Response) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+s3Router.get("/download/", strongJwtVerification(), s3ClientMiddleware, async (_req, res) => {
+    const payload = res.locals.payload;
     const s3 = res.locals.s3 as S3;
     const userId: string = payload.id;
 
@@ -93,9 +92,9 @@ s3Router.get("/download/", strongJwtVerification, s3ClientMiddleware, async (_re
  *     HTTP/1.1 403 Forbidden
  *     {"error": "Forbidden"}
  */
-s3Router.get("/download/:USERID", strongJwtVerification, s3ClientMiddleware, async (req: Request, res: Response) => {
+s3Router.get("/download/:USERID", strongJwtVerification(), s3ClientMiddleware, async (req, res) => {
     const userId: string | undefined = req.params.USERID;
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+    const payload = res.locals.payload;
     const s3 = res.locals.s3 as S3;
 
     if (!hasElevatedPerms(payload)) {

--- a/src/services/shop/shop-router.ts
+++ b/src/services/shop/shop-router.ts
@@ -1,15 +1,13 @@
 import crypto from "crypto";
 import { AttendeeProfile } from "database/attendee-db.js";
 import { ShopItem } from "database/shop-db.js";
-import { Request, Response, Router } from "express";
-import { NextFunction } from "express-serve-static-core";
+import { Router } from "express";
 import { StatusCode } from "status-code-enum";
 import Config from "../../config.js";
 import Models from "../../database/models.js";
 import { RouterError } from "../../middleware/error-handler.js";
 import { strongJwtVerification, weakJwtVerification } from "../../middleware/verify-jwt.js";
 import { hasAdminPerms, hasElevatedPerms } from "../auth/auth-lib.js";
-import { JwtPayload } from "../auth/auth-models.js";
 import { updateCoins } from "../profile/profile-lib.js";
 import { FilteredShopItemFormat, isValidItemFormat } from "./shop-formats.js";
 
@@ -43,7 +41,7 @@ import { FilteredShopItemFormat, isValidItemFormat } from "./shop-formats.js";
  * */
 
 const shopRouter: Router = Router();
-shopRouter.get("/", weakJwtVerification, async (_1: Request, res: Response, _2: NextFunction) => {
+shopRouter.get("/", weakJwtVerification(), async (_1, res, _2) => {
     const shopItems: ShopItem[] = await Models.ShopItem.find();
 
     const filteredData: FilteredShopItemFormat[] = shopItems.map((item: ShopItem) => ({
@@ -93,8 +91,8 @@ shopRouter.get("/", weakJwtVerification, async (_1: Request, res: Response, _2: 
  * @apiError (403: Forbidden) {String} InvalidPermission User does not have admin permissions.
  * @apiError (500: Internal Server Error) {String} InternalError An error occurred on the server.
  * */
-shopRouter.post("/item", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+shopRouter.post("/item", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
 
     // Check if the token has admin permissions
     if (!hasAdminPerms(payload)) {
@@ -158,8 +156,8 @@ shopRouter.post("/item", strongJwtVerification, async (req: Request, res: Respon
  * @apiError (404: Not Found) {String} ItemNotFound Item with itemId not found.
  * @apiError (500: Internal Server Error) {String} InternalError An error occurred on the server.
  */
-shopRouter.put("/item/:ITEMID", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+shopRouter.put("/item/:ITEMID", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
     const targetItem: string | undefined = req.params.ITEMID as string;
 
     const itemFormat = req.body as ShopItem;
@@ -206,8 +204,8 @@ shopRouter.put("/item/:ITEMID", strongJwtVerification, async (req: Request, res:
  * @apiError (403: Forbidden) {String} InvalidPermission User does not have admin permissions.
  * @apiError (500: Internal Server Error) {String} InternalError An error occurred on the server.
  */
-shopRouter.delete("/item/:ITEMID", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+shopRouter.delete("/item/:ITEMID", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
 
     // Check if the token has admin permissions
     if (!hasAdminPerms(payload)) {
@@ -244,9 +242,9 @@ shopRouter.delete("/item/:ITEMID", strongJwtVerification, async (req: Request, r
  * @apiError (404: Not Found) {String} ItemNotFound Item doesn't exist in the database.
  * @apiUse strongVerifyErrors
  */
-shopRouter.get("/item/qr/:ITEMID", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+shopRouter.get("/item/qr/:ITEMID", strongJwtVerification(), async (req, res, next) => {
     const targetItem: string | undefined = req.params.ITEMID as string;
-    const token: JwtPayload = res.locals.payload;
+    const token = res.locals.payload;
 
     if (!hasElevatedPerms(token)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
@@ -284,9 +282,9 @@ shopRouter.get("/item/qr/:ITEMID", strongJwtVerification, async (req: Request, r
  * @apiError (404: Not Found) {String} InvalidUniqueItem This unique item is already purchased or doesn't exist.
  * @apiError (500: Internal Server Error) {String} InternalError An error occurred on the server.
  */
-shopRouter.post("/item/buy", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
+shopRouter.post("/item/buy", strongJwtVerification(), async (req, res, next) => {
     const itemId: string | undefined = req.body.itemId as string;
-    const payload: JwtPayload = res.locals.payload as JwtPayload;
+    const payload = res.locals.payload;
     const userId: string = payload.id;
 
     const itemFormat: ShopItem | null = await Models.ShopItem.findOne({ itemId: itemId });

--- a/src/services/staff/staff-router.ts
+++ b/src/services/staff/staff-router.ts
@@ -1,7 +1,6 @@
-import { Router, Request, Response } from "express";
+import { Router } from "express";
 
 import { strongJwtVerification } from "../../middleware/verify-jwt.js";
-import { JwtPayload } from "../auth/auth-models.js";
 import { hasAdminPerms, hasStaffPerms } from "../auth/auth-lib.js";
 
 import { AttendanceFormat, isValidStaffShiftFormat } from "./staff-formats.js";
@@ -9,7 +8,6 @@ import Config from "../../config.js";
 
 import Models from "../../database/models.js";
 import { StatusCode } from "status-code-enum";
-import { NextFunction } from "express-serve-static-core";
 import { RouterError } from "../../middleware/error-handler.js";
 import { StaffShift } from "database/staff-db.js";
 
@@ -46,8 +44,8 @@ const staffRouter: Router = Router();
  *     HTTP/1.1 500 Internal Server Error
  *     {"error": "InternalError"}
  */
-staffRouter.post("/attendance/", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload | undefined = res.locals.payload as JwtPayload;
+staffRouter.post("/attendance/", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
 
     const eventId: string | undefined = (req.body as AttendanceFormat).eventId;
     const userId: string = payload.id;
@@ -77,8 +75,8 @@ staffRouter.post("/attendance/", strongJwtVerification, async (req: Request, res
     return res.status(StatusCode.SuccessOK).send({ status: "Success" });
 });
 
-staffRouter.get("/shift/", strongJwtVerification, async (_: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload | undefined = res.locals.payload as JwtPayload;
+staffRouter.get("/shift/", strongJwtVerification(), async (_, res, next) => {
+    const payload = res.locals.payload;
 
     if (!hasStaffPerms(payload)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));
@@ -100,8 +98,8 @@ staffRouter.get("/shift/", strongJwtVerification, async (_: Request, res: Respon
     return res.status(StatusCode.SuccessOK).json(events);
 });
 
-staffRouter.post("/shift/", strongJwtVerification, async (req: Request, res: Response, next: NextFunction) => {
-    const payload: JwtPayload | undefined = res.locals.payload as JwtPayload;
+staffRouter.post("/shift/", strongJwtVerification(), async (req, res, next) => {
+    const payload = res.locals.payload;
 
     if (!hasStaffPerms(payload)) {
         return next(new RouterError(StatusCode.ClientErrorForbidden, "Forbidden"));

--- a/src/services/version/version-router.ts
+++ b/src/services/version/version-router.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { Request, Response } from "express-serve-static-core";
 import Metadata from "../../metadata.js";
 import { StatusCode } from "status-code-enum";
 
@@ -18,7 +17,7 @@ const versionRouter: Router = Router();
  * }
  */
 
-versionRouter.get("/android/", async (_: Request, res: Response) => {
+versionRouter.get("/android/", async (_, res) => {
     const androidVersion: string = await Metadata.load("androidVersion");
     res.status(StatusCode.SuccessOK).send({ version: androidVersion });
 });
@@ -35,7 +34,7 @@ versionRouter.get("/android/", async (_: Request, res: Response) => {
  *   "version": "2024.1.1"
  * }
  */
-versionRouter.get("/ios/", async (_: Request, res: Response) => {
+versionRouter.get("/ios/", async (_, res) => {
     const iosVersion: string = await Metadata.load("iosVersion");
     res.status(StatusCode.SuccessOK).send({ version: iosVersion });
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+    interface Locals {
+        payload: unknown;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,3 +8058,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
Adds static type checking to `res.local.payload` if `strongJwtVerification()` or `weakJwtVerification()` is called, removing the need for `as JWTPayload` to ever be used. If `res.locals.payload` is accessed without calling one of the two middleware factories, then the type of `res.locals.payload` will be `unknown`.
```ts
router.get("/my-new-route-with-authorization/", strongJwtVerification(), async (_, res) => {
    const payload = res.locals.payload;
    //      ^?      JWTPayload
});

router.get("/my-new-route-with-authorization/", weakJwtVerification(), async (_, res) => {
    const payload = res.locals.payload;
    //      ^?      JWTPayload | undefined
});

router.get("/my-new-public-route/", async (_, res) => {
    const payload = res.locals.payload;
    //      ^?      unknown
});
```

I also went ahead and added doc comments to both `strongJwtVerification()` and `weakJwtVerification()` as both were not really clear as to what they do and what sets them apart.

### Some things to note
- Strongly typing all of the Express handlers causes no propagation across functions, which breaks this feature. It is best to let TypeScript use its type inferencing. Otherwise you would need to append additional generic hints to all the arguments:
```ts
router.get("/my-new-route/", strongJwtVerification(), async (_
: Request, res: Response) => {
    const payload = res.locals.payload;
    //      ^?      unknown
});
```

- If `strongJwtVerification()` or `weakJwtVerification()` is called, TypeScript will infer that all references to `res.locals.payload` are of type `JWTPayload.` If a handler function is run *before* `strongJwtVerification()` or `weakJwtVerification()` that reads `res.locals.payload`, it will lead to UB. Note that this isn't any better than mindlessly casting `res.locals.payload` to `JWTPayload` (what is currently being done on `main`).
```ts
router.get(
    "/my-new-route/",
    async (_, res) => {
        const payload = res.locals.payload;
        //      ^?      JWTPayload
        console.log(payload.id); // This will be UB
    },
    strongJwtVerification(),
);
```

I'm not sure if there is a way to give the next handler function a new context object in Express since the context `locals` is baked into `res`, and `req` and `res` are all mutably shared across all handlers, so I don't know if splitting contexts is a limitation of Express. I'm not too familiar with other frameworks, but for example, TRPC can modify context between handlers and middleware, allowing types to be hardened in future handlers (see first example: `ctx.user` is of type `User | undefined` and if the middleware succeeds, the new type of `ctx.user` that is passed to future is of type `User`): https://trpc.io/docs/server/middlewares