### PR TITLE
Change notifications to be batched by client

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "build": "tsc",
         "verify": "yarn build && yarn lint:check && yarn format:check",
         "serve": "node scripts/serve.mjs",
+        "send-notif": "node scripts/send-notif.js",
         "start": "vercel dev"
     },
     "keywords": [],

--- a/scripts/send-notif.js
+++ b/scripts/send-notif.js
@@ -1,0 +1,100 @@
+import inquirer from "inquirer";
+import axios from "axios";
+
+const options = [
+    {
+        type: "list",
+        name: "host",
+        message: "Select host (prod or local):",
+        choices: ["https://adonix.hackillinois.org", "http://localhost:3000"],
+    },
+    {
+        type: "password",
+        name: "token",
+        message: "Enter auth jwt token:",
+    },
+    {
+        type: "list",
+        name: "type",
+        message: "Select notification topic type:",
+        choices: ["role", "foodWave", "eventId", "staffShift"],
+    },
+    {
+        type: "input",
+        name: "id",
+        message: "Enter notification topic:",
+    },
+    {
+        type: "input",
+        name: "title",
+        message: "Enter notification title:",
+    },
+    {
+        type: "input",
+        name: "body",
+        message: "Enter notification body:",
+    },
+];
+
+const optionsConfirm = [
+    {
+        type: "confirm",
+        name: "confirm",
+        message: "Is the above correct?",
+    },
+];
+
+async function main() {
+    const answers = await inquirer.prompt(options);
+    const confirm = await inquirer.prompt(optionsConfirm);
+
+    if (!confirm.confirm) {
+        return;
+    }
+
+    const config = {
+        headers: {
+            Authorization: answers.token,
+        },
+    };
+
+    const batchResponse = await axios.post(
+        `${answers.host}/notification/batch`,
+        {
+            title: answers.title,
+            body: answers.body,
+            [answers.type]: answers.id,
+        },
+        config,
+    );
+
+    if (batchResponse.status != 200) {
+        throw new Error(`Failed to get notification batches: ${batchResponse}`);
+    }
+
+    const batches = batchResponse.data.batches;
+
+    const sendResponses = await Promise.all(
+        batches.map((batchId) =>
+            axios.post(
+                `${answers.host}/notification/send`,
+                {
+                    batchId,
+                },
+                config,
+            ),
+        ),
+    );
+
+    let sent = 0;
+    let failed = 0;
+
+    sendResponses.forEach((response) => {
+        sent += response.data.sent.length;
+        failed += response.data.failed.length;
+    });
+
+    console.log(`Notification sent to ${sent}, failed to send to ${failed}`);
+}
+
+main();

--- a/src/database/notification-db.ts
+++ b/src/database/notification-db.ts
@@ -8,6 +8,14 @@ export class NotificationMappings {
     public deviceToken: string;
 }
 
+class NotificationMessageBatch {
+    @prop({ required: true, type: () => [String] })
+    public sent!: string[];
+
+    @prop({ required: true, type: () => [String] })
+    public failed!: string[];
+}
+
 export class NotificationMessages {
     @prop({ required: true })
     public sender: string;
@@ -18,6 +26,6 @@ export class NotificationMessages {
     @prop({ required: true })
     public body: string;
 
-    @prop({ required: true })
-    public recipientCount: number;
+    @prop({ required: true, type: () => [NotificationMessageBatch] })
+    public batches!: NotificationMessageBatch[];
 }


### PR DESCRIPTION
- Change notifications to be batched by client
  - Now, POST /notification/batch to get a set of batch ids POST /notification/send for each batch id to send notifs. This makes it so the client requesting API handles pagination & sending requests so we don't run into Vercel's 10 second timeout.
- Add send-notif script