### PR TITLE
Update image tags to include 'v' prefix in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           ECR_URI: ${{ steps.login.outputs.registry }}/${{ env.ECR_REPOSITORY }}
         with:
           push: true
-          tags: ${{ env.ECR_URI }}:${{ github.sha }}
+          tags: ${{ env.ECR_URI }}:v${{ github.sha }}
           cache-from: type=registry,ref=${{ env.ECR_URI }}:cache
           cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ env.ECR_URI }}:cache
 
@@ -77,7 +77,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          image: ${{ steps.login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:v${{ github.sha }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@0e82244a9c6dac43d70151a94c67ebc4bab18fc5


### PR DESCRIPTION
There is a lifecycle policy in the Adonix ECR that cleans up any images without a tag prefixed with 'v'. This resulted in all of the release images being removed preventing deployment rollbacks.

This change prefixes all future image tags with 'v' so we can distinguish releases from other artifacts.